### PR TITLE
add reading always in utf8

### DIFF
--- a/osm/xml_handler.py
+++ b/osm/xml_handler.py
@@ -15,7 +15,7 @@ class PercentageFile(object):
     def __init__(self, filename: str) -> None:
         self.size = os.stat(filename)[6]
         self.delivered = 0
-        self.f = open(filename)
+        self.f = open(filename, encoding="utf-8")
         self.percentages = [1000] + [100 - 10 * x for x in range(0, 11)]
 
     def read(self, size: Optional[int] = None) -> str:


### PR DESCRIPTION
This PR fixes a problem reported on stackoverflow: https://gis.stackexchange.com/questions/346583/importing-road-graph-from-osm-file

Locally, I was unable to reproduce the problem, but this may be related to platform difference between Windows and Mac or Linux.