### PR TITLE
Make test suite resilient to missing networkx; fix OSMWay default

### DIFF
--- a/osm/osm_types.py
+++ b/osm/osm_types.py
@@ -9,7 +9,7 @@ class OSMWay:
     highway: str = field(init=False, default="")
     area: Optional[str] = field(init=False, default=None)
     max_speed_str: Optional[str] = field(init=False, default=None)
-    max_speed_int: int = field(init=False)
+    max_speed_int: int = field(init=False, default=0)
     direction: str = field(init=False, default="")
     forward: bool = field(init=False, default=True)
     backward: bool = field(init=False, default=True)

--- a/tests/convert_graph_test.py
+++ b/tests/convert_graph_test.py
@@ -1,3 +1,4 @@
+import importlib.util
 import random
 import string
 import unittest
@@ -5,6 +6,8 @@ import unittest
 from graph.convert_graph import convert_to_networkx
 from graph.graph import Graph
 from graph.graph_types import Edge, EdgeData, Vertex, VertexData
+
+networkx_available = importlib.util.find_spec("networkx") is not None
 
 
 def random_string(length=8):
@@ -15,6 +18,7 @@ def random_uint(max_val=1000):
     return random.randint(1, max_val)
 
 
+@unittest.skipUnless(networkx_available, "networkx is an optional dependency and is not installed")
 class TestConvertGraphTest(unittest.TestCase):
     def test_converting_K4_graph(self):
         g = self.create_graph(number_nodes=4)

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,5 +1,8 @@
+import importlib.util
 import unittest
 from subprocess import call
+
+networkx_available = importlib.util.find_spec("networkx") is not None
 
 
 class IntegrationTest(unittest.TestCase):
@@ -21,18 +24,12 @@ class IntegrationTest(unittest.TestCase):
         self.assertEqual(nmb_edges, 2039)
 
     def _execute_program(self):
-        returncode = call(
-            [
-                "python3",
-                "run.py",
-                "-f",
-                "data/karlsruhe_small.osm",
-                "-n",
-                "p",
-                "-c",
-                "--networkx",
-            ]
-        )
+        args = ["python3", "run.py", "-f", "data/karlsruhe_small.osm", "-n", "p", "-c"]
+        # --networkx requires the optional networkx dependency; only exercise
+        # it when networkx is actually installed
+        if networkx_available:
+            args.append("--networkx")
+        returncode = call(args)
         self.assertEqual(0, returncode)
 
     def _get_nmb_nodes_edges(self, path):


### PR DESCRIPTION
networkx is an optional dependency, but two tests failed outright when it was not installed:

- convert_graph_test: importing/calling convert_to_networkx raised NameError. The test class is now skipped via @skipUnless when networkx is unavailable.
- integration_test: run.py was always invoked with --networkx, which exits non-zero without networkx. --networkx is now only passed when networkx is installed, so the core pipeline is still exercised.

Also give OSMWay.max_speed_int a default of 0. It was declared with field(init=False) and no default, so accessing it on a way that was never accepted (max_speed_int never assigned) raised AttributeError.

Test suite now passes cleanly with or without networkx installed.